### PR TITLE
gst-ndi-sink: Mark collect_data as unowned

### DIFF
--- a/src/gst-ndi-sink.vala
+++ b/src/gst-ndi-sink.vala
@@ -195,7 +195,7 @@ namespace Gst.PluginNDI {
             }
 
             var newpad = new Gst.Pad.from_template (tmpl, pad_name);
-            unowned var collect_data = collect.add_pad (newpad, (uint)sizeof (Gst.Base.CollectData), null, true);
+            unowned Gst.Base.CollectData? collect_data = collect.add_pad (newpad, (uint)sizeof (Gst.Base.CollectData), null, true);
 
             if (collect_data == null) {
                 warning ("ndisink: Unable to add new pad to CollectPad");

--- a/src/gst-ndi-sink.vala
+++ b/src/gst-ndi-sink.vala
@@ -195,7 +195,7 @@ namespace Gst.PluginNDI {
             }
 
             var newpad = new Gst.Pad.from_template (tmpl, pad_name);
-            var collect_data = collect.add_pad (newpad, (uint)sizeof (Gst.Base.CollectData), null, true);
+            unowned var collect_data = collect.add_pad (newpad, (uint)sizeof (Gst.Base.CollectData), null, true);
 
             if (collect_data == null) {
                 warning ("ndisink: Unable to add new pad to CollectPad");


### PR DESCRIPTION
The documentation for gst_collect_pad_add_pad indicates that the returned
data structure is not owned by the caller, and should not be received. Mark
the collect_data variable as unowned so that the vala compiler does not add
code to needlessly duplicate the data structure.